### PR TITLE
add params option

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -28,7 +28,7 @@ class Node extends EventEmitter {
 
     // TODO: support regtest
     this.bitcoinJsNetwork = bitcoin.networks[network]
-    this.params = params[network]
+    this.params = opts.params || params[network]
     if (!this.bitcoinJsNetwork || !this.params) {
       throw Error(`Unknown network "${network}"`)
     }


### PR DESCRIPTION
passing in webcoin spv node parameters through `opts.params` makes it possible to initialize an spv node against a local regtest full node.